### PR TITLE
Other ansible playbooks that were not fully tested

### DIFF
--- a/ansible/curation_account_setup.yml
+++ b/ansible/curation_account_setup.yml
@@ -1,0 +1,24 @@
+# This is intended as a playbook of playbooks to set-up a UNIX account on a our curation services.
+# It *should*:
+#   1. Create the UNIX account for <<user>>,
+#   2. Install LD-Cool-P
+#   3. Set-up conda environment, and
+#   4. Update the .bashrc with LD-Cool-P settings
+# Note: This was not fully tested
+# Run via: ansible-playbook (-K) ansible/curation_account_setup.yml -i inventory -e "user=<username>"
+- name: "Create {{ user }} account"
+  import_playbook: ansible/debian_curation_account_create.yml
+  vars:
+    user: {{ user }}
+- name: Clone LD-Cool-P
+  import_playbook: ansible/git-pull_ldcoolp.yml
+  vars:
+    user: {{ user }}
+- name: Add bashrc conda initialization set-up
+  import_playbook: ansible/bashrc_conda_add.yml
+  vars:
+    user: {{ user }}
+- name: Add bashrc LD-Cool-P set-up
+  import_playbook: ansible/bashrc_ldcoolp_setup.yml
+  vars:
+    user: {{ user }}

--- a/ansible/debian_curation_account_create.yml
+++ b/ansible/debian_curation_account_create.yml
@@ -1,0 +1,22 @@
+# This was intended to be a script to add an account with sudo and curation privileges
+# Note that this was not fully tested and the password field should be passed in with
+# encryption done within the playbook
+# Note: This was not fully tested
+# Run via: ansible-playbook (-K) ansible/debian_account_create.yml -i inventory
+---
+- name: Create an account with curation group
+  hosts: curation
+  tasks:
+    - name: Create a login for {{ user }}
+      user:
+        name: "{{ user }}"
+        password: '???'
+        groups:
+         - curation
+         - sudo
+        state: present
+        shell: /bin/bash          # Defaults to /bin/bash
+        system: no                # Defaults to no
+        createhome: yes           # Defaults to yes
+        home: "/home/{{ user }}"  # Defaults to /home/<username>
+


### PR DESCRIPTION
There are two new playbooks that were developed some time ago that were not fully tested. I'm including them in this PR for possible future testing.
They are:
1. debian_curation_account_create - To create an account with membership in the `curation` group 
2. curation_account_setup - Intended to be a full set-up for a new curation account. Some work still needed (e.g., SSH keys)

